### PR TITLE
Feature: Query flags

### DIFF
--- a/src/BaseQuery.php
+++ b/src/BaseQuery.php
@@ -19,6 +19,16 @@ class BaseQuery
     protected $macros = array();
 
     /**
+     * Query flags
+     * These allow you to store data inside the query object.
+     * This data has no influence on the generated query string or parameters directly.
+     * But allow you to use the query a state mashine.
+     *  
+     * @var array
+     */
+    protected $flags = array();
+
+    /**
      * The callback where we fetch the results from
      *
      * @var callable
@@ -48,6 +58,7 @@ class BaseQuery
     protected function inheritFromParent(BaseQuery $parent)
     {
         $this->macros = $parent->macros;
+        $this->flags = $parent->flags;
         $this->resultFetcher = $parent->resultFetcher;   
     }
 
@@ -60,6 +71,34 @@ class BaseQuery
     public function setResultFetcher($resultFetcher = null)
     {
         $this->resultFetcher = $resultFetcher;
+    }
+
+    /**
+     * Set a flag on the query object
+     *
+     * @param string            $key
+     * @param mixed             $value
+     * @return void
+     */
+    final public function setFlag($key, $value)
+    {
+        $this->flags[$key] = $value;
+    }
+
+    /**
+     * Gets a flag from the query object
+     *
+     * @param string            $key
+     * @param mixed             $default
+     * @return void
+     */
+    final public function getFlag($key, $default = null)
+    {
+        if (!isset($this->flags[$key])) {
+            return $default;
+        }
+
+        return $this->flags[$key];
     }
 
     /**

--- a/tests/BaseQueryTest.php
+++ b/tests/BaseQueryTest.php
@@ -34,7 +34,7 @@ class BaseQueryTest extends \PHPUnit_Framework_TestCase
 		$query->setFlag('foo', 'bar');
 
 		$select = $query->select();
-		$this->assertInstanceOf(Select::class, $select);
+		$this->assertInstanceOf("ClanCats\\Hydrahon\\Query\\Sql\\Select", $select);
 
 		$this->assertEquals('bar', $select->getFlag('foo'));
 	}

--- a/tests/BaseQueryTest.php
+++ b/tests/BaseQueryTest.php
@@ -1,0 +1,41 @@
+<?php namespace ClanCats\Hydrahon\Test;
+/**
+ * Hydrahon base query test 
+ ** 
+ *
+ * @package 		Hydrahon
+ * @copyright 		Mario Döring
+ *
+ * @group Hydrahon
+ * @group Hydrahon_BaseQuery
+ */
+
+use ClanCats\Hydrahon\BaseQuery;
+use ClanCats\Hydrahon\Query\Sql\Table;
+use ClanCats\Hydrahon\Query\Sql\Select;
+
+class BaseQueryTest extends \PHPUnit_Framework_TestCase
+{
+	public function testFlags()
+	{
+		$query = new BaseQuery;
+
+		$this->assertNull($query->getFlag('foo'));
+		$this->assertEquals('bar', $query->getFlag('foo', 'bar'));
+
+		$query->setFlag('number', 42);
+		$this->assertEquals(42, $query->getFlag('number'));
+		$this->assertEquals(42, $query->getFlag('number', 'nope'));
+	}
+
+	public function testFlagInheritence()
+	{
+		$query = new Table;
+		$query->setFlag('foo', 'bar');
+
+		$select = $query->select();
+		$this->assertInstanceOf(Select::class, $select);
+
+		$this->assertEquals('bar', $select->getFlag('foo'));
+	}
+}

--- a/tests/Query/Sql/Select.php
+++ b/tests/Query/Sql/Select.php
@@ -162,6 +162,14 @@ class Query_Sql_Select_Test extends Query_QueryCase
 
 		// outer
 		$this->assertAttributes($this->createQuery()->outerJoin('avatars', 'users.id', '=', 'avatars.user_id'), array('joins' => array(array('outer', 'avatars', 'users.id', '=', 'avatars.user_id'))));
+
+		// join with raw values
+		$expression = new Expression("`avatars`.`user_id` and `avatars`.`active` = 1");
+
+		$this->assertAttributes(
+			$this->createQuery()->join('avatars', 'users.id', '=', new Expression("`avatars`.`user_id` and `avatars`.`active` = 1")), 
+			array('joins' => array(array('left', 'avatars', 'users.id', '=', $expression)))
+		);
 	}
 
 	/**

--- a/tests/Translator/Mysql.php
+++ b/tests/Translator/Mysql.php
@@ -413,6 +413,12 @@ class Translator_Mysql_Test extends TranslatorCase
 				->rightJoin('db1.orders as o', 'u.id', '=', 'o.user_id')
 				->innerJoin('profiles as p', 'u.id', '=', 'p.user_id');
 		});
+
+		// with raw values
+		$this->assertQueryTranslation('select * from `db1`.`users` as `u` left join `db1`.`groups` as `g` on `u`.`id` = `g`.`user_id` AND `g`.active = 1', array(), function($q) 
+		{
+			return $q->table('db1.users as u')->select()->join('db1.groups as g', 'u.id', '=', new Expression('`g`.`user_id` AND `g`.active = 1'));
+		});
 	}
 
 	/**


### PR DESCRIPTION
Query flags allow you to store parameters inside a query object. This can be very useful when passing a query object through multiple modifiers.