### PR TITLE
Added identifier escaping function

### DIFF
--- a/src/Translator/Mysql.php
+++ b/src/Translator/Mysql.php
@@ -39,12 +39,16 @@ class Mysql implements TranslatorInterface
     protected $attributes = array();
 
     /**
-     * The escape pattern escapes table column names etc.
-     * select * from `table`...
+     * Function to escape identifier names (columns and tables)
+     * Doubles backticks, removes null bytes
+     * https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
      *
      * @var string
      */
-    protected $escapePattern = '`%s`';
+    public function escapeIdentifier($identifier)
+    {
+        return '`'.str_replace(['`',"\0"],['``',''],$identifier).'`';
+    }
 
     /**
      * Translate the given query object and return the results as
@@ -230,13 +234,13 @@ class Mysql implements TranslatorInterface
 
             foreach ($string as $key => $item) 
             {
-                $string[$key] = $this->escapeString($item);
+                $string[$key] = $this->escapeIdentifier($item);
             }
 
             return implode('.', $string);
         }
 
-        return $this->escapeString($string);
+        return $this->escapeIdentifier($string);
     }
 
     /**
@@ -257,17 +261,6 @@ class Mysql implements TranslatorInterface
         }
 
         return $buffer . implode(', ', $arguments) . ')';
-    }
-
-    /**
-     * Escape a single string without checking for as and dots
-     *
-     * @param string     $string
-     * @return string
-     */
-    protected function escapeString($string)
-    {
-        return sprintf($this->escapePattern, $string);
     }
 
     /**


### PR DESCRIPTION
This modifies identifier escaping to correctly treat characters that break query syntax. It doubles the backticks and removes null bytes. It is based on [mysql's identifier naming rules](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html).
```php
$q->table('tbl')->select('col`b')->execute();
// before: select `col`b` from `tbl`  -- syntax error
// now: select `col``b` from `tbl`  -- works
```