### PR TITLE
support subqueries as where values

### DIFF
--- a/src/Translator/Mysql.php
+++ b/src/Translator/Mysql.php
@@ -540,7 +540,18 @@ class Mysql implements TranslatorInterface
             if (is_array($where[3])) 
             {
                 $where[3] = '(' . $this->parameterize($where[3]) . ')';
-            } else {
+            }
+            // when we have an entire query as where value, we 
+            // need to translate it and add its parameters to ours
+            elseif (is_object($where[3]) && ($where[3] instanceof BaseQuery))
+            {
+                $translator = new static;
+                list($sql, $params) = $translator->translate($where[3]);
+                foreach($params as $param) $this->addParameter($param);
+                $where[3] = '(' . $sql . ')';
+            }
+            else
+            {
                 $where[3] = $this->param($where[3]);
             }
 


### PR DESCRIPTION
Supports queries like this, which can be expressed as joins but are often easier to understand expressed this way--and faster to execute in MySQL:

```php
$rentals = $h->table('rental_properties');
$favorites = $h->table('user_favorite_rental_properties');
$rentals->select()->where('id', 'in',
    $favorites->
        select(['rental_property_id'])->
        where('user_id',$_SESSION['user_id'])
)->where('available', true);
```

becomes 

```sql
select * from `rental_properties` where `id` in (select `rental_property_id` from `user_favorite_rental_properties` where `user_id` = ?) and `available` = ?
```
```php
[12345, true]
```

I'm on a deadline at the moment but will come back later this week to add some tests if you want them and approve this general approach.